### PR TITLE
Removed potential security leak

### DIFF
--- a/backend/requests.add.php
+++ b/backend/requests.add.php
@@ -24,7 +24,8 @@ if(isset($formbt['phone']) && isset($formbt['typeofact']) && isset($formbt['type
 
     // Обработка ошибки соединения с БД
     if (mysqli_connect_errno()) {
-      echo json_encode ("Ошибка подключения к БД: %s\n".mysqli_connect_error(), JSON_UNESCAPED_UNICODE);
+      echo json_encode ("Ошибка подключения к БД", JSON_UNESCAPED_UNICODE);
+      error_log(mysqli_connect_error());
     }
     
     // Запись в БД        


### PR DESCRIPTION
It's not recommended to send mysqli-error details to the browser because it may reveal some credentials etc. 

**What was done**:
- Removed potential leak 
- Added error-log for better clarity

**How to test:**
- Review Changeset
- Checkout PR branch
- Test form usage when MySQL is down (should show error details only in logs)